### PR TITLE
Remove http-server dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "build": "npm-run-all --parallel build:*",
     "build:src": "rollup -c rollup.config.prod.js",
     "build:lib": "rollup -c rollup.config.lib.js",
-    "serve": "http-server -p 8080 -r .",
     "watch": "npm-run-all --parallel watch:*",
     "watch:src": "rollup --watch -c rollup.config.dev.js"
   },
@@ -45,7 +44,6 @@
   },
   "dependencies": {
     "@types/pubsub-js": "^1.5.17",
-    "http-server": "^0.9.0",
     "konva": "^1.6.0",
     "loglevel": "^1.4.1",
     "pubsub-js": "^1.5.6",


### PR DESCRIPTION
It brings in union ~0.4.3 which brings in qs ~2.3.3
which has a vulnerability
https://snyk.io/vuln/npm:qs:20170213

It doesn't seem like knerdie really needs http-server anyway